### PR TITLE
no more nifti toolbox

### DIFF
--- a/convert_ecat2nii.m
+++ b/convert_ecat2nii.m
@@ -22,9 +22,5 @@ nii_fname = fullfile(destination_path,[ecat_name '_flipped' nii_ext]);
 cmd = sprintf('mv %s %s',nii_fname,nii_file);
 system(cmd);
 
-% The header is wrongly written, fix this
-nii = load_nii(nii_file);
-save_nii(nii,nii_file);
-
 warning('The left and right sides may be reversed in the final nii file %s.\n',nii_file);
 end

--- a/run_magia.m
+++ b/run_magia.m
@@ -1,7 +1,5 @@
 function run_magia(subject)
 
-addpath /home/glereane/code/bramila/external/ISC_toolbox/niftitools
-
 megapet_dir = getenv('MEGAPET_HOME');
 data_path = getenv('DATA_DIR');
 D = sprintf('%s/%s',data_path,subject);


### PR DESCRIPTION
Previously Vesa's ecat2nii did not write the nifti header correctly. The problem was previously solved by loading the data into matlab and then re-writing it using nifti toolbox. Vesa fixed the problem and the nifti toolbox is thus no longer needed.