### PR TITLE
fix magia for ref modeling without mri

### DIFF
--- a/magia_processor.m
+++ b/magia_processor.m
@@ -42,6 +42,8 @@ roi_info = magia_get_roi_info(roi_set,tracer);
 
 if(~plasma)
     ref_region = magia_get_ref_region(tracer);
+    ref_idx = ismember(roi_info.labels,ref_region.label);
+    roi_info.labels(ref_idx) = [];
 end
 
 magia_clean_files(subject);


### PR DESCRIPTION
Aftet the fix, magia now removes the reference region from the variables roi_masks and roi_info.labels.