### PR TITLE
SUVR: Update calculation of time-integrals

### DIFF
--- a/magia_suvr.m
+++ b/magia_suvr.m
@@ -8,11 +8,11 @@ if(num_frames > 1)
     k = frames(:,1) >= start_time & frames(:,2) <= end_time;
     if(any(k))
         frames = frames(k,:);
+        frame_durs = frames(:,2) - frames(:,1);
         input = input(k);
         tacs = tacs(:,k);
-        t = mean(frames,2);
-        ref_auc = trapz(t,input);
-        roi_aucs = trapz(t,tacs')';
+        ref_auc = sum(frame_durs.*input);
+        roi_aucs = sum(repmat(frame_durs',[size(tacs,1) 1]).*tacs,2);
         suvr = roi_aucs./ref_auc;
     else
         error('Could not calculate SUVR because there are no data points between the specified start and end times.');


### PR DESCRIPTION
Previously the time-integrals were calculated using trapz. It is however also possible to calculate the time-integral of each frame by multiplying the average radioactivity concentration of the frame (given by the PET image) by the frame duration.