### PR TITLE
Update magia_match_units.m

### DIFF
--- a/magia_match_units.m
+++ b/magia_match_units.m
@@ -10,10 +10,10 @@ max_input = max(input(:,2));
 
 corrected_input = input;
 
-if(max_pet > 100 && max_input < 100)
+if(max_pet > 100 && max_input < 200)
     % pet bq, input kbq
     corrected_input(:,2) = input(:,2)*1000;
-elseif(max_pet < 100 && max_input > 100)
+elseif(max_pet < 100 && max_input > 200)
     % pet kbq, input bq
     corrected_input(:,2) = input(:,2)*0.001;
 end

--- a/magia_match_units.m
+++ b/magia_match_units.m
@@ -10,10 +10,10 @@ max_input = max(input(:,2));
 
 corrected_input = input;
 
-if(max_pet > 100 && max_input < 200)
+if(max_pet > 200 && max_input < 200)
     % pet bq, input kbq
     corrected_input(:,2) = input(:,2)*1000;
-elseif(max_pet < 100 && max_input > 200)
+elseif(max_pet < 200 && max_input > 200)
     % pet kbq, input bq
     corrected_input(:,2) = input(:,2)*0.001;
 end


### PR DESCRIPTION
Max input of 200 kBq/mL should cover most of the inputs found so far and it is still not high enough to exclude 200 Bq/mL = 0.2 kBq/mL inputs (an unrealistically too low peak).